### PR TITLE
添加对使用ModelEngine的MythicMobs插件生物兼容性

### DIFF
--- a/src/main/java/me/xjqsh/lrtactical/capability/CombatProperties.java
+++ b/src/main/java/me/xjqsh/lrtactical/capability/CombatProperties.java
@@ -199,12 +199,12 @@ public class CombatProperties {
             this.stack = stack;
         }
 
+        /**
+         * 由服务器判断
+         */
         @Override
         public void perform(Player player) {
-            if (stack.getItem() instanceof IMeleeWeapon weapon && weapon.isSame(stack, player.getMainHandItem())) {
-                List<Entity> entities = weapon.collectTargets(player, stack, action, player.getEyePosition(), player.getLookAngle());
-                NetworkHandler.CHANNEL.sendToServer(new CMeleeAttackRequest(action, entities));
-            }
+            NetworkHandler.CHANNEL.sendToServer(new CMeleeAttackRequest(action));
         }
     }
 

--- a/src/main/java/me/xjqsh/lrtactical/network/message/CMeleeAttackRequest.java
+++ b/src/main/java/me/xjqsh/lrtactical/network/message/CMeleeAttackRequest.java
@@ -1,39 +1,27 @@
 package me.xjqsh.lrtactical.network.message;
 
 import me.xjqsh.lrtactical.EquipmentMod;
+import me.xjqsh.lrtactical.api.item.IMeleeWeapon;
 import me.xjqsh.lrtactical.api.melee.MeleeAction;
 import me.xjqsh.lrtactical.capability.CombatPropertiesProvider;
 import me.xjqsh.lrtactical.config.ServerConfig;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
-public record CMeleeAttackRequest(
-        MeleeAction action,
-        int[] entityIds
-) {
-    public CMeleeAttackRequest(MeleeAction action, List<Entity> entities) {
-        this(action, toList(entities));
-    }
-
-    private static int[] toList(List<Entity> entities) {
-        return entities.stream().mapToInt(Entity::getId).limit(ServerConfig.MELEE_MAX_TARGET_PER_PACKET.get()).toArray();
-    }
-
+public record CMeleeAttackRequest(MeleeAction action) {
     public static void encode(CMeleeAttackRequest message, FriendlyByteBuf buf) {
         buf.writeEnum(message.action);
-        buf.writeVarIntArray(message.entityIds);
     }
 
     public static CMeleeAttackRequest decode(FriendlyByteBuf buf) {
         MeleeAction action = buf.readEnum(MeleeAction.class);
-        int[] ids = buf.readVarIntArray();
-        return new CMeleeAttackRequest(action, ids);
+        return new CMeleeAttackRequest(action);
     }
 
     public static void handle(CMeleeAttackRequest message, Supplier<NetworkEvent.Context> contextSupplier) {
@@ -44,27 +32,25 @@ public record CMeleeAttackRequest(
                 if (player == null) {
                     return;
                 }
-
-                if (message.entityIds.length > ServerConfig.MELEE_MAX_TARGET_PER_PACKET.get()) {
-                    EquipmentMod.LOGGER.info(
-                            "Player {} tried to attack too many entities at once: {}! Ignoring.",
-                            player.getName().getString(),
-                            message.entityIds.length
-                    );
-                    return;
-                }
-
-                List<Entity> entities = new ArrayList<>();
-                for (int entityId : message.entityIds()) {
-                    Entity entity = player.level().getEntity(entityId);
-                    if (entity != null) {
-                        entities.add(entity);
+                ItemStack stack = player.getMainHandItem();
+                /*
+                  改为由服务器去判断实体进行攻击，对于像ModelEngine插件这种不存在ID的生物会有帮助
+                 */
+                if (stack.getItem() instanceof IMeleeWeapon weapon && weapon.isSame(stack, player.getMainHandItem())) {
+                    List<Entity> entities = weapon.collectTargets(player, stack, message.action, player.getEyePosition(), player.getLookAngle());
+                    if (entities.size() > ServerConfig.MELEE_MAX_TARGET_PER_PACKET.get()) {
+                        EquipmentMod.LOGGER.info(
+                                "Player {} tried to attack too many entities at once: {}! Ignoring.",
+                                player.getName().getString(),
+                                entities.size()
+                        );
+                        return;
                     }
+                    player.getCapability(CombatPropertiesProvider.CAPABILITY).ifPresent(cap -> {
+                        cap.postAttack(message.action, entities);
+                    });
                 }
 
-                player.getCapability(CombatPropertiesProvider.CAPABILITY).ifPresent(cap -> {
-                    cap.postAttack(message.action, entities);
-                });
             });
         }
         context.setPacketHandled(true);


### PR DESCRIPTION
 改为由服务器去判断实体进行攻击，对于像使用了ModelEngine的MythicMobs插件这种不存在ID的生物会有帮助